### PR TITLE
Fix Decode-For-Ghost link

### DIFF
--- a/projects/decode/index.kit
+++ b/projects/decode/index.kit
@@ -47,7 +47,7 @@
 		
 		<section class="ghost" id="ghost">
 			<img class="section-head" src="images/decode-for-ghost.png">
-			<div class="desc"><p>I've also made a port of Decode for <a href="https://ghost.org">Ghost</a>. It doesn't have all the features of the WordPress version because Ghost is a nascent blogging platform, but I'll be sure to add in features as Ghost evolves. It can be downloaded <a href="https://github.com/ScottSmith95/Decode/releases/latest">on GitHub</a> as well.</p>
+			<div class="desc"><p>I've also made a port of Decode for <a href="https://ghost.org">Ghost</a>. It doesn't have all the features of the WordPress version because Ghost is a nascent blogging platform, but I'll be sure to add in features as Ghost evolves. It can be downloaded <a href="https://github.com/ScottSmith95/Decode-for-Ghost/releases/latest">on GitHub</a> as well.</p>
 			<div class="options">
 				<a class="button demo" href="http://decode-ghost-demo.scotthsmith.com/">Demo</a>
 				<a class="button download" href="https://github.com/ScottSmith95/Decode-for-Ghost/releases/latest">Download</a>


### PR DESCRIPTION
I noticed the link on your site pointed to wordpress decode when it should have been pointing to decode for ghost.